### PR TITLE
Disable auto merge and implement auto watch update

### DIFF
--- a/.github/workflows/watch.yaml
+++ b/.github/workflows/watch.yaml
@@ -31,17 +31,6 @@ jobs:
             - name: Show changes
               run: git status
 
-            - name: Check write access to repo
-              run: |
-                  token_login=$(curl -H "Authorization: Bearer ${token}" https://api.github.com/user | jq -r '.login')
-                  echo token login is ${token_login}
-                  echo $(curl  -H "Authorization: Bearer ${token}" https://api.github.com/repos/${repo}/collaborators/${token_login}/permission) > result
-                  cat result | jq  '.permission == "admin" // .permission == "write"' > /dev/null || ( echo "Token does not have write access to ${repo}" >> ${GITHUB_STEP_SUMMARY}; exit 1)
-                  curl -sS -f -I -H "Authorization: Bearer ${token}" https://api.github.com | grep 'x-oauth-scopes:' | grep 'repo' > /dev/null && exit 0 || echo "Token does not have repo scope on ${repo}" >> ${GITHUB_STEP_SUMMARY}
-              env:
-                  repo: symfony-php-recipes-bot/symfony-recipes-php
-                  token: ${{ secrets.BOT_TOKEN}}
-
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@v4
               with:


### PR DESCRIPTION
> Secrets are not passed to workflows that are triggered by a pull request from a fork. [Learn more about encrypted secrets](https://docs.github.com/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets).